### PR TITLE
Add missing trial and il regions to non-interactive init

### DIFF
--- a/src/workato_platform/cli/commands/init.py
+++ b/src/workato_platform/cli/commands/init.py
@@ -14,7 +14,7 @@ from workato_platform.client.workato_api.configuration import Configuration
 @click.option("--profile", help="Profile name to use (creates new if doesn't exist)")
 @click.option(
     "--region",
-    type=click.Choice(["us", "eu", "jp", "au", "sg", "custom"]),
+    type=click.Choice(["us", "eu", "jp", "au", "sg", "il", "trial", "custom"]),
     help="Workato region",
 )
 @click.option("--api-token", help="Workato API token")


### PR DESCRIPTION
## Summary
- Added missing `trial` and `il` regions to the `--region` option in non-interactive init mode
- Ensures consistency between interactive and non-interactive modes

## Changes
Updated `src/workato_platform/cli/commands/init.py` to include all available regions in the `--region` choice parameter.

## Testing
Verified that the `--region` option now accepts:
- `us`, `eu`, `jp`, `au`, `sg` (previously available)
- `il`, `trial` (newly added)
- `custom` (previously available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)